### PR TITLE
Fixed: Send logging was empty.

### DIFF
--- a/src/main/java/com/wedevol/xmpp/server/CcsClient.java
+++ b/src/main/java/com/wedevol/xmpp/server/CcsClient.java
@@ -170,7 +170,7 @@ public class CcsClient implements StanzaListener {
 		});
 
 		// Log all outgoing packets
-		connection.addPacketInterceptor(stanza -> logger.log(Level.INFO, "Sent: {}", stanza.toXML()),
+		connection.addPacketInterceptor(stanza -> logger.log(Level.INFO, "Sent: " + stanza.toXML()),
 				ForEveryStanza.INSTANCE);
 
 		// Set the ping interval


### PR DESCRIPTION
Send logging was always empty (Sent: {}). I replaced {} by the argument.